### PR TITLE
"static_assert(false)" is ill-formed in "if constexpr" before CWG2518.

### DIFF
--- a/Homeworks/9_PathTracing/project/src/UEditor/Cmpt/Inspector.cpp
+++ b/Homeworks/9_PathTracing/project/src/UEditor/Cmpt/Inspector.cpp
@@ -81,7 +81,7 @@ protected:
 		else if constexpr (N == 4)
 			ImGui::DragFloat4((string(classname) + "::" + name).c_str(), floatN.data(), 0.01f, f32_min, f32_max);
 		else
-			static_assert(false, "N = 1, 2, 3, 4");
+			static_assert(N > 4 || N < 0, "N = 1, 2, 3, 4");
 	};
 
 	template<typename Obj>


### PR DESCRIPTION
Change "false" to "N > 4 || N < 0" in static_assert

Only the GCC version above 13.0 can compile the code like:
```cpp
template<typename T>
void f()
{
    if constexpr ([std::is_arithmetic_v](http://en.cppreference.com/w/cpp/types/is_arithmetic)<T>)
        // ...
    else {
        using invalid_array = int[-1]; // ill-formed: invalid for every T
        static_assert(false, "Must be arithmetic"); // ill-formed before CWG2518
    }
}
```
(from [cppreference](https://en.cppreference.com/w/cpp/language/if))

Before CWG2518, we can code:
```cpp
template<typename>
inline constexpr bool dependent_false_v = false;
 
template<typename T>
void f()
{
    if constexpr ([std::is_arithmetic_v](http://en.cppreference.com/w/cpp/types/is_arithmetic)<T>)
        // ...
    else {
        // workaround before CWG2518
        static_assert(dependent_false_v<T>, "Must be arithmetic");
    }
}
```